### PR TITLE
Permit to silence errors (ex. warnings...)

### DIFF
--- a/src/setup.php
+++ b/src/setup.php
@@ -37,6 +37,11 @@ function _setup_whoops() {
 	$whoops = new Run();
 	$whoops->pushHandler( new PrettyPageHandler() );
 	$whoops->register();
+
+	if ( defined( 'DEBUG_TOOLKIT_WHOOPS_SILENCE_ERRORS' ) ) {
+		// Ignore some levels on all the website
+		$whoops->silenceErrorsInPaths( '/.*/', $levels = DEBUG_TOOLKIT_WHOOPS_SILENCE_ERRORS );
+	}
 }
 
 /**


### PR DESCRIPTION
Usage example:

```php
define( 'DEBUG_TOOLKIT_WHOOPS_SILENCE_ERRORS', E_STRICT | E_DEPRECATED | E_WARNING | E_NOTICE );
```