### PR TITLE
Run only if not in cli context

### DIFF
--- a/src/setup.php
+++ b/src/setup.php
@@ -22,9 +22,11 @@ use Whoops\Run;
  * @access private
  */
 function _setup_plugin() {
-	_setup_whoops();
-	_setup_admin_bar();
-	_register_kint_aliases();
+	if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+		_setup_whoops();
+		_setup_admin_bar();
+		_register_kint_aliases();
+	}
 }
 
 /**


### PR DESCRIPTION
Without this condition, when an error is thrown in wp-cli context, the script dies with no message at all.